### PR TITLE
Перевести картинки с base64 на файлы

### DIFF
--- a/src/app/global/cdk/components/event-card/abstract-event-card.ts
+++ b/src/app/global/cdk/components/event-card/abstract-event-card.ts
@@ -25,6 +25,7 @@ export abstract class AbstractEventCard {
     }
 
     return new Intl.DateTimeFormat('ru-RU', {
+      year: 'numeric',
       month: 'long',
       day: 'numeric',
       hour: 'numeric',

--- a/src/app/global/cdk/components/event-card/abstract-event-card.ts
+++ b/src/app/global/cdk/components/event-card/abstract-event-card.ts
@@ -17,9 +17,19 @@ export abstract class AbstractEventCard {
 
   public map: mapboxgl.Map | null = null
 
-  public generateStartTime(date: ISO8601): string {
+  public generateStartTime(date: ISO8601, isOnlyTimeShow: boolean = true): string {
     const parsedDate: Date = new Date(date)
-    return new Intl.DateTimeFormat('ru-RU', { hour: 'numeric', minute: 'numeric' }).format(parsedDate)
+
+    if (isOnlyTimeShow) {
+      return new Intl.DateTimeFormat('ru-RU', { hour: 'numeric', minute: 'numeric' }).format(parsedDate)
+    }
+
+    return new Intl.DateTimeFormat('ru-RU', {
+      month: 'long',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric'
+    }).format(parsedDate)
   }
 
   public generateDistanceString(distance: number): string {

--- a/src/app/global/services/config/config.service.ts
+++ b/src/app/global/services/config/config.service.ts
@@ -3,4 +3,6 @@ import { Injectable } from '@angular/core'
 @Injectable({ providedIn: 'root' })
 export class ConfigService {
   public readonly baseApiUrl: string = `https://api.becycled.me`
+
+  public readonly apiImageUrl: string = `${ this.baseApiUrl }/images`
 }

--- a/src/app/global/services/image-network/image-network.service.ts
+++ b/src/app/global/services/image-network/image-network.service.ts
@@ -14,6 +14,6 @@ export class ImageNetworkService {
    * Возвращает имя файла. Поддерживает форматы PNG и JPG
    */
   public uploadImage(uploadImageData: FormData): Observable<string> {
-    return this.httpClient.post(`${ this.configService.baseApiUrl }/images/upload`, uploadImageData, { responseType: 'text' })
+    return this.httpClient.post(`${ this.configService.apiImageUrl }/upload`, uploadImageData, { responseType: 'text' })
   }
 }

--- a/src/app/global/services/image-network/image-network.service.ts
+++ b/src/app/global/services/image-network/image-network.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core'
+import { HttpClient } from '@angular/common/http'
+import { Observable } from 'rxjs'
+import { ConfigService } from '../config/config.service'
+
+@Injectable()
+export class ImageNetworkService {
+
+  constructor(private httpClient: HttpClient,
+              private configService: ConfigService) {
+  }
+
+  /**
+   * Возвращает имя файла. Поддерживает форматы PNG и JPG
+   */
+  public uploadImage(uploadImageData: FormData): Observable<string> {
+    return this.httpClient.post(`${ this.configService.baseApiUrl }/images/upload`, uploadImageData, { responseType: 'text' })
+  }
+}

--- a/src/app/global/services/index.ts
+++ b/src/app/global/services/index.ts
@@ -1,2 +1,3 @@
 export * from './config/config.service'
 export * from './user-holder/user-holder.service'
+export * from './image-network/image-network.service'

--- a/src/app/modules/add-event/add-event.module.ts
+++ b/src/app/modules/add-event/add-event.module.ts
@@ -32,6 +32,7 @@ import { TuiRippleModule } from '@taiga-ui/addon-mobile'
 import { WorkoutService } from '../../global/domain/services/workout/workout.service'
 import { CompetitionService } from '../../global/domain/services/competition/competition.service'
 import { RouteService } from '../../global/domain/services/route/route.service'
+import { ImageNetworkService } from '../../global/services'
 
 @NgModule({
   declarations: [
@@ -66,7 +67,8 @@ import { RouteService } from '../../global/domain/services/route/route.service'
     MapboxNetworkService,
     WorkoutService,
     CompetitionService,
-    RouteService
+    RouteService,
+    ImageNetworkService
   ]
 })
 export class AddEventModule {

--- a/src/app/modules/add-event/components/add-event/add-event.component.ts
+++ b/src/app/modules/add-event/components/add-event/add-event.component.ts
@@ -424,63 +424,66 @@ export class AddEventComponent implements OnInit {
              * Создаем Blob, чтобы загрузить его на наш сервер
              */
             this.map!.getCanvas().toBlob((blob: Blob | null) => {
-              if (blob !== null) {
-                const uploadImageData: FormData = new FormData()
-
-                uploadImageData.append('imageFile', blob, 'route.png')
-
-                /**
-                 * Загружаем сгенерированное preview на сервер
-                 */
-                this.imageNetworkService.uploadImage(uploadImageData).pipe(
-                  switchMap((imageName: string) => {
-                    this.preview = `${ this.configService.apiImageUrl }/${ imageName }`
-
-                    /**
-                     * Создаем маршрут с указанием в preview имени файла с картинкой
-                     */
-                    return this.createRouteByUserId(currentUser.id).pipe(
-                      switchMap((route: Route) => {
-
-                        /**
-                         * Создаем событие в зависимости от выбранного типа
-                         */
-                        switch (this.eventForm.get('eventType')?.value) {
-                          case EventType.workout:
-                            return this.createWorkoutByRouteAndUserId(route, currentUser.id).pipe(
-                              tap(() => {
-                                this.isLoading = false
-
-                                this.notificationsService
-                                  .show('Тренировка успешно добавлена', {
-                                    status: TuiNotification.Success
-                                  }).subscribe()
-
-                                this.routerService.navigate([ '' ])
-                              })
-                            )
-                          case EventType.competition:
-                            return this.createCompetitionByRouteAndUserId(route, currentUser.id).pipe(
-                              tap(() => {
-                                this.isLoading = false
-
-                                this.notificationsService
-                                  .show('Соревнование успешно добавлено', {
-                                    status: TuiNotification.Success
-                                  }).subscribe()
-
-                                this.routerService.navigate([ '' ])
-                              })
-                            )
-                          default:
-                            throw new Error('Не указан тип события')
-                        }
-                      })
-                    )
-                  }),
-                  take(1)
-                ).subscribe()
+              if (blob === null) {
+                return
               }
+
+              const uploadImageData: FormData = new FormData()
+
+              uploadImageData.append('imageFile', blob, 'route.png')
+
+              /**
+               * Загружаем сгенерированное preview на сервер
+               */
+              this.imageNetworkService.uploadImage(uploadImageData).pipe(
+                switchMap((imageName: string) => {
+                  this.preview = `${ this.configService.apiImageUrl }/${ imageName }`
+
+                  /**
+                   * Создаем маршрут с указанием в preview имени файла с картинкой
+                   */
+                  return this.createRouteByUserId(currentUser.id).pipe(
+                    switchMap((route: Route) => {
+
+                      /**
+                       * Создаем событие в зависимости от выбранного типа
+                       */
+                      switch (this.eventForm.get('eventType')?.value) {
+                        case EventType.workout:
+                          return this.createWorkoutByRouteAndUserId(route, currentUser.id).pipe(
+                            tap(() => {
+                              this.isLoading = false
+
+                              this.notificationsService
+                                .show('Тренировка успешно добавлена', {
+                                  status: TuiNotification.Success
+                                }).subscribe()
+
+                              this.routerService.navigate([ '' ])
+                            })
+                          )
+                        case EventType.competition:
+                          return this.createCompetitionByRouteAndUserId(route, currentUser.id).pipe(
+                            tap(() => {
+                              this.isLoading = false
+
+                              this.notificationsService
+                                .show('Соревнование успешно добавлено', {
+                                  status: TuiNotification.Success
+                                }).subscribe()
+
+                              this.routerService.navigate([ '' ])
+                            })
+                          )
+                        default:
+                          throw new Error('Не указан тип события')
+                      }
+                    })
+                  )
+                }),
+                take(1)
+              ).subscribe()
+
             })
           })
         }

--- a/src/app/modules/add-event/components/add-event/add-event.component.ts
+++ b/src/app/modules/add-event/components/add-event/add-event.component.ts
@@ -1,21 +1,21 @@
-import { ChangeDetectionStrategy, Component, Inject, OnInit } from '@angular/core'
-import { TUI_IS_ANDROID, TUI_IS_IOS, TuiDay, TuiTime } from '@taiga-ui/cdk'
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core'
 import { FormControl, FormGroup, Validators } from '@angular/forms'
-import mapboxgl, { AnyLayer, LngLat, LngLatBoundsLike } from 'mapbox-gl'
-import { MapboxNetworkService } from '../../../../global/services/mapbox-network/mapbox-network.service'
-import { DirectionType, MapboxRouteGeoData, Route, SportType, User, Workout } from '../../../../global/domain'
-import { map, startWith, switchMap, take, tap } from 'rxjs/operators'
-import { generateBounds, generateGeoJsonFeature } from '../../../../global/utils'
+import { Title } from '@angular/platform-browser'
+import { Router } from '@angular/router'
+import { TUI_IS_ANDROID, TUI_IS_IOS, TuiDay, TuiTime } from '@taiga-ui/cdk'
+import { TuiNotification, TuiNotificationsService } from '@taiga-ui/core'
 import { TUI_MOBILE_AWARE } from '@taiga-ui/kit'
-import { EventType, ISO8601 } from '../../../../global/models'
+import mapboxgl, { AnyLayer, LngLat, LngLatBoundsLike } from 'mapbox-gl'
 import { Observable } from 'rxjs'
-import { ConfigService, ImageNetworkService, UserHolderService } from '../../../../global/services'
-import { WorkoutService } from '../../../../global/domain/services/workout/workout.service'
+import { map, startWith, switchMap, take, tap } from 'rxjs/operators'
+import { DirectionType, MapboxRouteGeoData, Route, SportType, User, Workout } from '../../../../global/domain'
 import { CompetitionService } from '../../../../global/domain/services/competition/competition.service'
 import { RouteService } from '../../../../global/domain/services/route/route.service'
-import { Router } from '@angular/router'
-import { TuiNotification, TuiNotificationsService } from '@taiga-ui/core'
-import { Title } from '@angular/platform-browser'
+import { WorkoutService } from '../../../../global/domain/services/workout/workout.service'
+import { EventType, ISO8601 } from '../../../../global/models'
+import { ConfigService, ImageNetworkService, UserHolderService } from '../../../../global/services'
+import { MapboxNetworkService } from '../../../../global/services/mapbox-network/mapbox-network.service'
+import { generateBounds, generateGeoJsonFeature } from '../../../../global/utils'
 
 const blankGeoJsonFeature: GeoJSON.Feature<GeoJSON.Geometry> = {
   type: 'Feature',
@@ -114,8 +114,7 @@ export class AddEventComponent implements OnInit {
               private routeService: RouteService,
               private routerService: Router,
               private title: Title,
-              @Inject(TuiNotificationsService)
-              private readonly notificationsService: TuiNotificationsService,
+              private notificationsService: TuiNotificationsService,
               private imageNetworkService: ImageNetworkService,
               private configService: ConfigService) {
     this.title.setTitle(`Новое событие`)

--- a/src/app/modules/competition-page/components/competition-page/competition-page.component.html
+++ b/src/app/modules/competition-page/components/competition-page/competition-page.component.html
@@ -1,6 +1,6 @@
 <tui-island *tuiLet="competition$ | async as competition">
   <ng-container *ngIf="competition">
-    <h3 class="tui-island__title">{{ generateStartTime(competition.startDate) }}</h3>
+    <h3 class="tui-island__title">{{ generateStartTime(competition.startDate, false) }}</h3>
     <p class="tui-island__category">Соревнование</p>
     <mgl-map
       [style]="'mapbox://styles/mapbox/streets-v11'"

--- a/src/app/modules/competition-page/components/competition-page/competition-page.component.html
+++ b/src/app/modules/competition-page/components/competition-page/competition-page.component.html
@@ -9,7 +9,7 @@
       [attributionControl]="false"
       [doubleClickZoom]="false"
       [zoom]="15"
-      [center]="[ 39.949127487394094,43.414052415946685 ]"
+      [center]="[ 38.97616408756599, 45.04022357823186 ]"
       (mapLoad)="onMapboxLoad($event)"
     >
       <mgl-geojson-source

--- a/src/app/modules/profile/containers/profile-container/profile-container.component.html
+++ b/src/app/modules/profile/containers/profile-container/profile-container.component.html
@@ -5,7 +5,7 @@
       <tui-input-file
         *ngIf="isEdit"
         [formControl]="avatarFileReader"
-        accept="image/png,image/jpg"
+        accept="image/png,image/jpg,image/jpeg"
         [maxFileSize]="maxFileSize"
         link="Выберите файл"
         label="или перетащите его (макс. 1Мб)"

--- a/src/app/modules/profile/containers/profile-container/profile-container.component.html
+++ b/src/app/modules/profile/containers/profile-container/profile-container.component.html
@@ -5,7 +5,7 @@
       <tui-input-file
         *ngIf="isEdit"
         [formControl]="avatarFileReader"
-        accept="image/*"
+        accept="image/png,image/jpg"
         [maxFileSize]="maxFileSize"
         link="Выберите файл"
         label="или перетащите его (макс. 1Мб)"

--- a/src/app/modules/profile/profile.module.ts
+++ b/src/app/modules/profile/profile.module.ts
@@ -2,13 +2,31 @@ import { CommonModule } from '@angular/common'
 import { NgModule } from '@angular/core'
 import { ReactiveFormsModule } from '@angular/forms'
 import { TuiLetModule } from '@taiga-ui/cdk'
-import { TuiButtonModule, TuiFormatPhonePipeModule, TuiGroupModule, TuiHintModule, TuiLinkModule, TuiNotificationModule, TuiTextfieldControllerModule } from '@taiga-ui/core'
-import { TuiFieldErrorModule, TuiFilterModule, TuiInputFileModule, TuiInputInlineModule, TuiInputModule, TuiInputPhoneModule, TuiIslandModule, TuiTextAreaModule } from '@taiga-ui/kit'
+import {
+  TuiButtonModule,
+  TuiFormatPhonePipeModule,
+  TuiGroupModule,
+  TuiHintModule,
+  TuiLinkModule,
+  TuiNotificationModule,
+  TuiTextfieldControllerModule
+} from '@taiga-ui/core'
+import {
+  TuiFieldErrorModule,
+  TuiFilterModule,
+  TuiInputFileModule,
+  TuiInputInlineModule,
+  TuiInputModule,
+  TuiInputPhoneModule,
+  TuiIslandModule,
+  TuiTextAreaModule
+} from '@taiga-ui/kit'
 import { NgxMapboxGLModule } from 'ngx-mapbox-gl'
 import { EventCardModule } from '../../global/cdk/components/event-card/event-card.module'
 import { ProfileContainerComponent } from './containers/profile-container/profile-container.component'
 
 import { ProfileRoutingModule } from './profile-routing.module'
+import { ImageNetworkService } from '../../global/services'
 
 @NgModule({
   declarations: [
@@ -36,6 +54,9 @@ import { ProfileRoutingModule } from './profile-routing.module'
     NgxMapboxGLModule,
     TuiNotificationModule,
     TuiHintModule
+  ],
+  providers: [
+    ImageNetworkService
   ]
 })
 export class ProfileModule { }

--- a/src/app/modules/workout-page/components/workout-page.component.html
+++ b/src/app/modules/workout-page/components/workout-page.component.html
@@ -1,6 +1,6 @@
 <tui-island *tuiLet="workout$ | async as workout">
   <ng-container *ngIf="workout">
-    <h3 class="tui-island__title">{{ generateStartTime(workout.startDate) }}</h3>
+    <h3 class="tui-island__title">{{ generateStartTime(workout.startDate, false) }}</h3>
     <p class="tui-island__category">Тренировка</p>
     <mgl-map
       [style]="'mapbox://styles/mapbox/streets-v11'"

--- a/src/app/modules/workout-page/components/workout-page.component.html
+++ b/src/app/modules/workout-page/components/workout-page.component.html
@@ -9,7 +9,7 @@
       [attributionControl]="false"
       [doubleClickZoom]="false"
       [zoom]="15"
-      [center]="[ 39.949127487394094,43.414052415946685 ]"
+      [center]="[ 38.97616408756599, 45.04022357823186 ]"
       (mapLoad)="onMapboxLoad($event)"
     >
       <mgl-geojson-source


### PR DESCRIPTION
Исправил отображение дат на странице ивентов (теперь дата отображается полностью).
Теперь изображения отправляются на бэк не в base64, а предварительно загружаются и сохраняется полная ссылка на файл.